### PR TITLE
add dependencies to setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,10 @@ setup(
         '':["*.ui"], # include QT ui files 
         },
     
+    install_requires=['numpy', 'qtpy', 'h5py', 'pyqtgraph'],
+
+    extras_require={
+        'all' : ['qtconsole', 'pyqt5'],
+    }
+
     )


### PR DESCRIPTION
This PR closes #18 and modifies the `setup.py` file to make ScopeFoundry installation for the end user with all the dependencies included with the option to exclude them if required.

With the new additions, users can:

### Install ScopeFoundry with direct dependencies (numpy, qtpy, pyqtgraph, h5py)
```bash 
pip install ScopeFoundry
```
### Install ScopeFoundry with *all* dependencies (numpy, qtpy, pyqtgraph, h5py *and* pyqt5, qtconsole)
```bash 
pip install ScopeFoundry[all]
```

### Install ScopeFoundry with *NO* dependencies (this would be the same as the current installation)
```bash 
pip install ScopeFoundry --no-deps
```