### PR TITLE
Update databrowser

### DIFF
--- a/data_browser.py
+++ b/data_browser.py
@@ -219,14 +219,17 @@ class FileInfoView(DataBrowserView):
     def on_change_data_filename(self, fname=None):
         if fname is None:
             fname = self.databrowser.settings['data_filename']
-
-        _, ext = os.path.splitext(fname)
+        
+        # Use pathlib
+        fname = Path(fname)
+        
+        ext = fname.suffix
         
         if ext in ('.py', '.ini', '.txt'):
             with open(fname, 'r') as f:
                 self.ui.setText(f.read())
         else:
-            self.ui.setText(fname)
+            self.ui.setText(str(fname))
         
     def is_file_supported(self, fname):
         return True

--- a/data_browser.py
+++ b/data_browser.py
@@ -1,20 +1,23 @@
 from __future__ import division, print_function, absolute_import
+
+import os
+from pathlib import Path
+from collections import OrderedDict
+import argparse
+import time
+from datetime import datetime
+
 from ScopeFoundry import BaseApp
 from ScopeFoundry.helper_funcs import load_qt_ui_file, sibling_path,\
     load_qt_ui_from_pkg
 from ScopeFoundry.widgets import RegionSlicer
-from collections import OrderedDict
-import os
+from ScopeFoundry.logged_quantity import LQCollection
 from qtpy import QtCore, QtWidgets, QtGui
 import pyqtgraph as pg
 import pyqtgraph.dockarea as dockarea
 import numpy as np
-from ScopeFoundry.logged_quantity import LQCollection
 from scipy.stats import spearmanr
-import argparse
-import time
 import h5py
-from datetime import datetime
 
 
 class DataBrowser(BaseApp):

--- a/data_browser.py
+++ b/data_browser.py
@@ -41,6 +41,9 @@ class DataBrowser(BaseApp):
         self.ui.show()
         self.ui.raise_()
         
+        self.ui.setWindowTitle("ScopeFoundry: Data Browser")
+        self.ui.setWindowIcon(QtGui.QIcon('scopefoundry_logo2C_1024.png'))
+        
         self.views = OrderedDict()        
         self.current_view = None        
 

--- a/data_browser.py
+++ b/data_browser.py
@@ -33,9 +33,7 @@ class DataBrowser(BaseApp):
                 val = getattr(args,lq.name)
                 if val is not None:
                     lq.update_value(val)
-        
-    
-    
+
     def setup(self):
 
         #self.ui = load_qt_ui_file(sibling_path(__file__, "data_browser.ui"))
@@ -55,7 +53,6 @@ class DataBrowser(BaseApp):
         self.settings.New('auto_select_view',dtype=bool, initial=True)
 
         self.settings.New('view_name', dtype=str, initial='0', choices=('0',))
-        
         
         # UI Connections
         self.settings.data_filename.connect_to_browse_widgets(self.ui.data_filename_lineEdit, 
@@ -77,14 +74,11 @@ class DataBrowser(BaseApp):
         self.tree_selectionModel = self.ui.treeView.selectionModel()
         self.tree_selectionModel.selectionChanged.connect(self.on_treeview_selection_change)
 
-
         self.settings.browse_dir.add_listener(self.on_change_browse_dir)
         self.settings['browse_dir'] = os.getcwd()
 
-        # set views
-        
+        # Load file information view as default view
         self.load_view(FileInfoView(self))
-        self.load_view(NPZView(self))
 
         self.settings.view_name.add_listener(self.on_change_view_name)
         self.settings['view_name'] = "file_info"

--- a/data_browser.py
+++ b/data_browser.py
@@ -90,8 +90,6 @@ class DataBrowser(BaseApp):
         self.ui.log_pushButton.clicked.connect(self.logging_widget.show)
         self.ui.show()
         
-
-        
     def load_view(self, new_view):
         print("loading view", repr(new_view.name))
         
@@ -135,7 +133,6 @@ class DataBrowser(BaseApp):
         self.ui.treeView.setRootIndex(self.fs_model.index(self.settings['browse_dir']))
         self.fs_model.setRootPath(self.settings['browse_dir'])
 
-    
     def on_change_file_filter(self):
         self.log.debug("on_change_file_filter")
         filter_str = self.settings['file_filter']
@@ -145,7 +142,7 @@ class DataBrowser(BaseApp):
         filter_str_list = [x.strip() for x in filter_str.split(',')]
         self.log.debug(filter_str_list)
         self.fs_model.setNameFilters(filter_str_list)
-                    
+
     def on_change_view_name(self):
         #print('on_change_view_name')
         previous_view = self.current_view
@@ -206,7 +203,8 @@ class DataBrowserView(QtCore.QObject):
         return False
         
 class FileInfoView(DataBrowserView):
-    
+    """A general viewer to handle text files and
+    unsupported file types."""
     name = 'file_info'
     
     def setup(self):
@@ -229,7 +227,9 @@ class FileInfoView(DataBrowserView):
 
 
 class NPZView(DataBrowserView):
+    """Reads Numpy Z files (npz)
     
+    """
     name = 'npz_view'
     
     def setup(self):
@@ -267,8 +267,6 @@ class NPZView(DataBrowserView):
         
     def is_file_supported(self, fname):
         return os.path.splitext(fname)[1] == ".npz"
-    
-    
 
 
 class HyperSpectralBaseView(DataBrowserView):
@@ -1000,14 +998,11 @@ def peak_map(hyperspectral_data, wls, thres, min_dist, refinement, ignore_phony_
                                min_dist=min_dist, refinement=refinement,
                                ignore_phony_refinements=ignore_phony_refinements)
 
-    
-
-
-
 if __name__ == '__main__':
     import sys
     
     app = DataBrowser(sys.argv)
+    app.load_view(NPZView(app))
     app.load_view(HyperSpectralBaseView(app))
 
     sys.exit(app.exec_())

--- a/data_browser.py
+++ b/data_browser.py
@@ -1000,6 +1000,7 @@ def peaks(spec, wls, thres=0.5, unique_solution=True,
         return peaks_x[0]
     else:
         return peaks_x
+
 def peak_map(hyperspectral_data, wls, thres, min_dist, refinement, ignore_phony_refinements):
     return np.apply_along_axis(peaks, -1, hyperspectral_data, 
                                wls=wls, thres=thres, 


### PR DESCRIPTION
I have made some changes to the data browser. This is work I did while implementing a browser for TEM data using `ncempy` (see [here](https://github.com/ercius/ncempy_browser)).

I pulled the npz_view out of the main `__init__` so that all DataBrowser classes dont have to use it. I added it back in where the HyperSpectralBaseView (and all other views) are loaded.

The Window now has a proper title and icon.

I suggest we move to pathlib.Path instead of os.path. I tried to implement this in FileInfo, but Im not 100% sure how we could do this as a default for the rest of the views and functions. 