### PR TITLE
Dev 160 connect_to_widget bugfix

### DIFF
--- a/base_app/base_microscope_app.py
+++ b/base_app/base_microscope_app.py
@@ -14,13 +14,12 @@ from qtpy import QtCore, QtGui, QtWidgets
 from ScopeFoundry import h5_io, ini_io
 from ScopeFoundry.helper_funcs import (
     OrderedAttrDict,
-    sibling_path,
-    load_qt_ui_file,
     confirm_on_close,
     ignore_on_close,
+    load_qt_ui_file,
+    sibling_path,
 )
 from ScopeFoundry.logged_quantity import LoggedQuantity, new_tree
-
 
 from .base_app import BaseApp
 
@@ -271,11 +270,11 @@ class BaseMicroscopeApp(BaseApp):
 
     def set_subwindow_mode(self):
         """Switches Multiple Document Interface to Subwindowed viewing mode."""
-        self.ui.mdiArea.setViewMode(self.ui.mdiArea.SubWindowView)
+        self.ui.mdiArea.setViewMode(QtWidgets.QMdiArea.ViewMode.SubWindowView)
 
     def set_tab_mode(self):
         """Switches Multiple Document Interface to Tabbed viewing mode."""
-        self.ui.mdiArea.setViewMode(self.ui.mdiArea.TabbedView)
+        self.ui.mdiArea.setViewMode(QtWidgets.QMdiArea.ViewMode.TabbedView)
 
     def tile_layout(self):
         """Tiles subwindows in user interface. Specifically in the Multi Document Interface."""
@@ -291,11 +290,11 @@ class BaseMicroscopeApp(BaseApp):
         self.bring_mdi_subwin_to_front(measure.subwin)
 
     def bring_mdi_subwin_to_front(self, subwin):
-        viewMode = self.ui.mdiArea.viewMode()
-        if viewMode == self.ui.mdiArea.SubWindowView:
+        view_mode = self.ui.mdiArea.viewMode()
+        if view_mode == QtWidgets.QMdiArea.ViewMode.TabbedView:
             subwin.showNormal()
             subwin.raise_()
-        elif viewMode == self.ui.mdiArea.TabbedView:
+        elif view_mode == QtWidgets.QMdiArea.ViewMode.SubWindowView:
             subwin.showMaximized()
             subwin.raise_()
 

--- a/logged_quantity/collection.py
+++ b/logged_quantity/collection.py
@@ -17,7 +17,7 @@ class LQCollectionQObject(QtCore.QObject):
     new_lq_added = QtCore.Signal((LoggedQuantity,))
     lq_removed = QtCore.Signal((LoggedQuantity,))
 
-    def __init__(self, settings, parent: QtCore.QObject | None = None) -> None:
+    def __init__(self, settings, parent: QtCore.QObject = None) -> None:
         super().__init__(parent)
         self.settings = settings
 

--- a/logged_quantity/logged_quantity.py
+++ b/logged_quantity/logged_quantity.py
@@ -102,18 +102,10 @@ class LoggedQuantity(QtCore.QObject):
         self.description = description
 
         self.colors = colors
-        self.qcolors = []
-        if self.colors:
-            default_color = QtGui.QColor("lightgrey")
-            for color in colors:
-                try:
-                    qcolor = QtGui.QColor(color)
-                except TypeError:
-                    qcolor = default_color
-                if qcolor.isValid():
-                    self.qcolors.append(qcolor)
-                else:
-                    self.qcolors.append(default_color)
+        if colors:
+            self.qcolors = [to_q_color(color) for color in colors]
+        else:
+            self.qcolors = []
 
         self.log = get_logger_from_class(self)
 
@@ -584,28 +576,33 @@ class LoggedQuantity(QtCore.QObject):
             widget.textChanged.connect(on_widget_textChanged)
 
         elif type(widget) == QtWidgets.QComboBox:
-            # need to have a choice list to connect to a QComboBox
             assert self.choices is not None
             widget.clear()  # removes all old choices
+
             for choice_name, choice_value in self.choices:
                 widget.addItem(choice_name, choice_value)
             self.updated_choice_index_value[int].connect(widget.setCurrentIndex)
             widget.currentIndexChanged.connect(self.update_choice_index_value)
-            if self.colors != None:
-                if len(self.qcolors) == len(self.choices):
-                    for i, qcolor in enumerate(self.qcolors):
-                        widget.setItemData(i, qcolor, QtCore.Qt.BackgroundRole)
 
-                    def update_background_color(idx):
-                        qcolor = self.qcolors[idx]
-                        s = f"""QComboBox{{
-                                    selection-background-color: {qcolor.name()};
-                                    selection-color: black;
-                                    background: {qcolor.name()};
-                                    }}"""
-                        widget.setStyleSheet(widget.styleSheet() + s)
+            if self.colors is None:
+                return
+            for i, qcolor in enumerate(self.qcolors):
+                widget.setItemData(i, qcolor, QtCore.Qt.BackgroundRole)
 
-                    widget.currentIndexChanged.connect(update_background_color)
+            def update_background_color(idx):
+                if idx < len(self.qcolors):
+                    qc = self.qcolors[idx]
+                else:
+                    qc = QtGui.QColor("white")
+
+                s = f"""QComboBox{{
+                            selection-background-color: {qc.name()};
+                            selection-color: black;
+                            background: {qc.name()};
+                            }}"""
+                widget.setStyleSheet(widget.styleSheet() + s)
+
+            widget.currentIndexChanged.connect(update_background_color)
 
         elif type(widget) == pyqtgraph.widgets.SpinBox.SpinBox:
             # widget.setFocusPolicy(QtCore.Qt.StrongFocus)
@@ -810,21 +807,26 @@ class LoggedQuantity(QtCore.QObject):
             for choice_name, choice_value in self.choices:
                 widget.addItem(choice_name, choice_value)
             self.updated_choice_index_value[int].connect(widget.setCurrentIndex)
-            if self.colors != None:
-                if len(self.qcolors) == len(self.choices):
-                    for i, qcolor in enumerate(self.qcolors):
-                        widget.setItemData(i, qcolor, QtCore.Qt.BackgroundRole)
 
-                    def update_background_color(idx):
-                        qcolor = self.qcolors[idx]
-                        s = f"""QComboBox{{
-                                    selection-background-color: {qcolor.name()};
-                                    selection-color: black;
-                                    background: {qcolor.name()};
-                                    }}"""
-                        widget.setStyleSheet(widget.styleSheet() + s)
+            if self.colors is None:
+                return
+            for i, qcolor in enumerate(self.qcolors):
+                widget.setItemData(i, qcolor, QtCore.Qt.BackgroundRole)
 
-                    widget.currentIndexChanged.connect(update_background_color)
+            def update_background_color(idx):
+                if idx < len(self.qcolors):
+                    qc = self.qcolors[idx]
+                else:
+                    qc = QtGui.QColor("white")
+
+                s = f"""QComboBox{{
+                            selection-background-color: {qc.name()};
+                            selection-color: black;
+                            background: {qc.name()};
+                            }}"""
+                widget.setStyleSheet(widget.styleSheet() + s)
+
+            widget.currentIndexChanged.connect(update_background_color)
 
         elif type(widget) == pyqtgraph.widgets.SpinBox.SpinBox:
             # widget.setFocusPolicy(QtCore.Qt.StrongFocus)
@@ -1264,3 +1266,12 @@ class LoggedQuantity(QtCore.QObject):
                 cmenu.addAction(f"{val}", partial(self.update_value, new_val=val))
 
         cmenu.exec_(QtGui.QCursor.pos())
+
+
+def to_q_color(color):
+    try:
+        qcolor = QtGui.QColor(color)
+        if qcolor.isValid():
+            return qcolor
+    except TypeError:
+        return QtGui.QColor("lightgrey")

--- a/logged_quantity/tree.py
+++ b/logged_quantity/tree.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import OrderedDict, Protocol
+from typing import OrderedDict, Protocol, List, Union
 
 from qtpy import QtCore, QtGui, QtWidgets
 
@@ -19,15 +19,16 @@ class SubtreeAbleObj(Protocol):
     operations: OrderedDict
     q_object: SubtreeAblesQObject
 
-    def add_sub_tree(self, tree: QtWidgets.QTreeWidget, sub_tree): ...
+    def add_sub_tree(self, tree: QtWidgets.QTreeWidget, sub_tree): ...  # optional
 
     def on_right_click(self): ...  # optional
 
 
-def new_tree(objs: list[SubtreeAbleObj], header=["col0", ""]) -> QtWidgets.QTreeWidget:
+def new_tree(objs: List[SubtreeAbleObj], header=["col0", ""]) -> QtWidgets.QTreeWidget:
     tree = QtWidgets.QTreeWidget()
     tree.setColumnCount(len(header))
     tree.setHeaderLabels(header)
+    tree.setColumnWidth(0, 180)
     tree.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
     tree.customContextMenuRequested.connect(partial(on_right_click, tree=tree))
 
@@ -39,7 +40,7 @@ def new_tree(objs: list[SubtreeAbleObj], header=["col0", ""]) -> QtWidgets.QTree
 
 class SFQTreeWidgetItem(QtWidgets.QTreeWidgetItem):
 
-    obj: SubtreeAbleObj | LoggedQuantity | OrderedDict
+    obj: Union[SubtreeAbleObj, LoggedQuantity, OrderedDict]
 
 
 class ObjSubtree:
@@ -94,7 +95,7 @@ class ObjSubtree:
 def remove_from_tree(
     name: str,
     root_item: SFQTreeWidgetItem,
-    children: dict[str, SFQTreeWidgetItem],
+    children,  # dict[str, SFQTreeWidgetItem],
 ) -> None:
     item = children.pop(name, None)
     if item is None:
@@ -103,9 +104,9 @@ def remove_from_tree(
 
 
 def update_operations(
-    operations: dict[str, None],
+    operations: OrderedDict,
     root_item: QtWidgets.QTreeWidgetItem,
-    children: dict[str, QtWidgets.QTreeWidgetItem],
+    children,  #: dict[str, QtWidgets.QTreeWidgetItem],
 ) -> None:
     for op_name, op_func in operations.items():
         if op_name in children:
@@ -121,7 +122,7 @@ def update_operations(
 def update_settings(
     settings: LQCollection,
     root_item: SFQTreeWidgetItem,
-    children: dict[str, SFQTreeWidgetItem],
+    children,  #: dict[str, SFQTreeWidgetItem],
 ) -> None:
     for lqname, lq in tuple(settings.iter(exclude=children.keys())):
         if isinstance(lq, ArrayLQ):

--- a/measurement.py
+++ b/measurement.py
@@ -554,9 +554,7 @@ class MeasurementQbject(QtCore.QObject):
     operation_added = QtCore.Signal(str)
     operation_removed = QtCore.Signal(str)
 
-    def __init__(
-        self, measurement: Measurement, parent: QtCore.QObject | None = None
-    ) -> None:
+    def __init__(self, measurement: Measurement, parent: QtCore.QObject = None) -> None:
         super().__init__(parent)
         self.m = measurement
         self.display_update_timer = QtCore.QTimer()

--- a/tests/lq_widget_test.py
+++ b/tests/lq_widget_test.py
@@ -110,6 +110,7 @@ class Measure(Measurement):
         self.ui = pg.QtWidgets.QWidget()
         vsplitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         layout = pg.QtWidgets.QVBoxLayout(self.ui)
+        layout.addWidget(self.activation.new_pushButton())
         layout.addWidget(vsplitter)
         vsplitter.addWidget(
             new_tree(

--- a/tests/lq_widget_test.py
+++ b/tests/lq_widget_test.py
@@ -62,6 +62,12 @@ class Measure(Measurement):
 
     def setup(self):
 
+        self.settings.New(
+            "color test",
+            str,
+            choices=("yellow", "blue", "grey"),
+            colors=("yellow", "blue"),
+        )
         self.settings.New("amplitude", dtype=float, initial=1.0)
         self.settings.New("run_crash_immediately", dtype=bool, initial=False)
         self.settings.New("run_crash_middle", dtype=bool, initial=False)
@@ -107,9 +113,9 @@ class Measure(Measurement):
             )
         )
 
-        self.ui = pg.QtWidgets.QWidget()
+        self.ui = QtWidgets.QWidget()
         vsplitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
-        layout = pg.QtWidgets.QVBoxLayout(self.ui)
+        layout = QtWidgets.QVBoxLayout(self.ui)
         layout.addWidget(self.activation.new_pushButton())
         layout.addWidget(vsplitter)
         vsplitter.addWidget(


### PR DESCRIPTION
Includes text from PR #50. _New stuff in italic_

### Features added:

- LQs can now hold 3 previous and 7 proposed values. Values are proposed when ini files are saved and read from .h5 and .ini files specified by the "inspect file" LQ.
- right click on widget associated with LQs shows previous and proposed values
- connected the ui's "about" and "doc" action to launching a webbrowser and displaying readme.md
- PID controller has a min and max value that is fed to the plant.
- LQCollection can now dynamical add/remove LQs. 
- BaseApp, HardwareComponent, Measurements can now dynamically add/remove operations.
- Added a function to generate a tree widget of operations and settings from BaseApp, Measurement and HardwareComponent. The tree widget updates when operations/LQ are added removed.

### Fixes:

- #46 
- ini file loading of bool lq arrays
- _Checkboxes, and pushButtons no longer throw Errors when updating due to LQ value change while using newer PySide6 versions_

### Architecture change:

- Split logged_quantity and base_app into packages.  Fully backwards compatible.
- lq_path concept and .ini loading functionality moved from base_microscope_app to base_app.
- expose LQ init arguments to the LQCollection.New method to facilitate usage with linting.
- New Pattern: BaseApp, HardwareComponent, Measurements and LQCollection now all have `attr::q_object` which isolate Qt related functionality and prevent namespace clashes.
- HardwareComponent, Measurements no longer inherit from QObject.