### PR TITLE
Dev160 app on_close fixes

### DIFF
--- a/base_app/base_microscope_app.py
+++ b/base_app/base_microscope_app.py
@@ -330,6 +330,9 @@ class BaseMicroscopeApp(BaseApp):
             self.log.info("disconnecting {}".format(hw.name))
             if hw.settings["connected"]:
                 try:
+                    # terminate the update thread
+                    hw.enable_connection(enable=False)
+                    # then call the hw component's disconnect method
                     hw.disconnect()
                 except Exception as err:
                     self.log.error("tried to disconnect {}: {}".format(hw.name, err))

--- a/base_app/base_microscope_app.py
+++ b/base_app/base_microscope_app.py
@@ -319,6 +319,12 @@ class BaseMicroscopeApp(BaseApp):
 
     def on_close(self):
         self.log.info("on_close")
+
+        # remove QT handler and reference to avoid atexit exception
+        if hasattr(self, 'logging_widget_handler'):
+            logging.getLogger().removeHandler(self.logging_widget_handler)
+            self.logging_widget_handler = None
+
         # disconnect all hardware objects
         for hw in self.hardware.values():
             self.log.info("disconnecting {}".format(hw.name))


### PR DESCRIPTION
Fixed runtime error when closing the scopefoundry app in py 3.12+ by removing the qt logging handler in on_close. 
```sh
Exception ignored in atexit callback: <function shutdown at 0x7fe54b73f1a0>
Traceback (most recent call last):
  File "/home/mark/anaconda3/envs/scopefoundry/lib/python3.12/logging/__init__.py", line 2263, in shutdown
    if getattr(h, 'flushOnClose', True):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
Also added call to hardware.enable_connection to terminate the update thread of any connected hw components.
Currently in both py 3.12 and below the update thread gets caught in its run loop whenever the scopefoundry app is closed while still connecting to a device, repeatedly printing:

>WARNING:LoggedQuantity:pr read_from_hardware called when not connected to hardware

