### PR TITLE
Add dynamic loading and unloading of HardwareComponents and Measurements

### DIFF
--- a/base_app/base_app.py
+++ b/base_app/base_app.py
@@ -249,6 +249,12 @@ class BaseApp(QtCore.QObject):
         for lq in settings.as_dict().values():
             self.add_setting_path(lq)
 
+    def remove_lq_collection_from_settings_path(self, settings: LQCollection) -> None:
+        settings.q_object.lq_added.disconnect(self.add_setting_path)
+        settings.q_object.lq_removed.disconnect(self.remove_setting_path)
+        for lq in settings.as_dict().values():
+            self.remove_setting_path(lq)
+
     def write_setting(self, path: str, value: Any) -> WRITE_RES:
         lq = self.get_lq(path)
         if lq is None:

--- a/base_app/base_microscope_app.py
+++ b/base_app/base_microscope_app.py
@@ -206,8 +206,8 @@ class BaseMicroscopeApp(BaseApp):
 
     def _setup_ui_tree_column(self) -> None:
 
-        mm_tree = new_tree_widget(self.measurements.values(), ["Measurements", "Value"])
-        hw_tree = new_tree_widget(self.hardware.values(), ["Hardware", "Value"])
+        self.mm_tree = new_tree_widget(self.measurements.values(), ["Measurements", "Value"])
+        self.hw_tree = new_tree_widget(self.hardware.values(), ["Hardware", "Value"])
         app_widget = new_widget(
             obj=self,
             title="app",
@@ -235,8 +235,8 @@ class BaseMicroscopeApp(BaseApp):
 
         splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Vertical)
         splitter.addWidget(self.favorites_widget.scroll_area)
-        splitter.addWidget(hw_tree)
-        splitter.addWidget(mm_tree)
+        splitter.addWidget(self.hw_tree)
+        splitter.addWidget(self.mm_tree)
         splitter.addWidget(app_widget)
         self.ui.tree_layout.addWidget(splitter)
 
@@ -466,21 +466,52 @@ class BaseMicroscopeApp(BaseApp):
         If *hw* is a class, rather an instance, create an instance
         and add it to self.hardware
         """
-        assert not hw.name in self.hardware.keys()
-
         # If *hw* is a class, rather an instance, create an instance
         if inspect.isclass(hw):
             hw = hw(app=self)
 
+        if hw.name in self.hardware.keys():
+            raise ValueError(f"Hardware '{hw.name}' already exists. Remove it first with app.remove_hardware('{hw.name}')")
+
         self.hardware.add(hw.name, hw)
 
         self.add_lq_collection_to_settings_path(hw.settings)
+
+        if hasattr(self, 'hw_tree'):
+            from ScopeFoundry.dynamical_widgets.tree_widget import SubtreeManager
+            SubtreeManager(self.hw_tree, hw)
 
         return hw
 
     def add_hardware_component(self, hw: HardwareProtocol) -> HardwareProtocol:
         # DEPRECATED use add_hardware()
         return self.add_hardware(hw)
+
+    def remove_hardware(self, name: str) -> None:
+        if name not in self.hardware:
+            self.log.warning(f"Hardware {name} not found")
+            return
+        
+        hw = self.hardware[name]
+        
+        if hw.is_connected:
+            self.log.info(f"Disconnecting {name} before removal")
+            hw.settings["connected"] = False
+        
+        for subtree_manager in list(hw._subtree_managers_):
+            subtree_manager.cleanup()
+        hw._subtree_managers_.clear()
+        
+        for widget_manager in list(hw._widgets_managers_):
+            if hasattr(widget_manager, 'deleteLater'):
+                widget_manager.deleteLater()
+        hw._widgets_managers_.clear()
+        
+        self.remove_lq_collection_from_settings_path(hw.settings)
+        
+        del self.hardware[name]
+        
+        self.log.info(f"Hardware {name} removed")
 
     def add_measurement(self, measure: MeasurementProtocol) -> MeasurementProtocol:
         """Loads a Measurement object into the app.
@@ -493,11 +524,22 @@ class BaseMicroscopeApp(BaseApp):
         if inspect.isclass(measure):
             measure = measure(app=self)
 
-        assert not measure.name in self.measurements.keys()
+        if measure.name in self.measurements.keys():
+            raise ValueError(f"Measurement '{measure.name}' already exists. Remove it first with app.remove_measurement('{measure.name}')")
 
         self.measurements.add(measure.name, measure)
 
         self.add_lq_collection_to_settings_path(measure.settings)
+
+        if hasattr(self, 'mm_tree'):
+            from ScopeFoundry.dynamical_widgets.tree_widget import SubtreeManager
+            SubtreeManager(self.mm_tree, measure)
+
+        if self.mdi and hasattr(self, 'ui'):
+            ui = self.load_measure_ui(measure)
+            if ui is not None:
+                subwin = self.add_mdi_subwin(ui, measure.name)
+                measure.subwin = subwin
 
         return measure
 
@@ -506,6 +548,57 @@ class BaseMicroscopeApp(BaseApp):
     ) -> MeasurementProtocol:
         # DEPRECATED, use add_measurement()
         return self.add_measurement(measure)
+
+    def remove_measurement(self, name: str) -> None:
+        if name not in self.measurements:
+            self.log.warning(f"Measurement {name} not found")
+            return
+        
+        measure = self.measurements[name]
+        
+        if measure.is_measuring():
+            self.log.info(f"Interrupting {name} before removal")
+            measure.interrupt()
+            if hasattr(measure, 'acq_thread') and measure.acq_thread:
+                measure.acq_thread.wait(5000)
+        
+        if hasattr(measure, 'q_object') and hasattr(measure.q_object, 'display_update_timer'):
+            measure.q_object.display_update_timer.stop()
+        
+        for subtree_manager in list(measure._subtree_managers_):
+            subtree_manager.cleanup()
+        measure._subtree_managers_.clear()
+        
+        for widget_manager in list(measure._widgets_managers_):
+            if hasattr(widget_manager, 'deleteLater'):
+                widget_manager.deleteLater()
+        measure._widgets_managers_.clear()
+        
+        for show_btn in measure._show_btns:
+            show_btn.deleteLater()
+        measure._show_btns.clear()
+        
+        if name in self._loaded_measure_uis:
+            ui = self._loaded_measure_uis[name]
+            if ui and hasattr(measure, 'subwin') and measure.subwin:
+                if self.mdi:
+                    self.ui.mdiArea.removeSubWindow(measure.subwin)
+                    measure.subwin.deleteLater()
+                else:
+                    ui.close()
+                    ui.deleteLater()
+            del self._loaded_measure_uis[name]
+        
+        for action in self.ui.menuWindow.actions():
+            if action.text() == name:
+                self.ui.menuWindow.removeAction(action)
+                break
+        
+        self.remove_lq_collection_from_settings_path(measure.settings)
+        
+        del self.measurements[name]
+        
+        self.log.info(f"Measurement {name} removed")
 
     def add_favorites(
         self,

--- a/dynamical_widgets/tree_widget.py
+++ b/dynamical_widgets/tree_widget.py
@@ -131,6 +131,35 @@ class SubtreeManager:
         if color is not None:
             self.header_item.setForeground(col, QtGui.QColor(color))
 
+    def cleanup(self):
+        self.settings.q_object.lq_added.disconnect(self.add_lq_child_item)
+        self.settings.q_object.lq_removed.disconnect(self.remove_lq_child_item)
+        self.operations.q_object.added.disconnect(self.add_operation_child_item)
+        self.operations.q_object.removed.disconnect(self.remove_operation_child_item)
+        
+        for child_item in list(self.settings_items.values()):
+            widget = self.tree_widget.itemWidget(child_item, 1)
+            if widget:
+                widget.deleteLater()
+            self.header_item.removeChild(child_item)
+        
+        for child_item in list(self.operation_items.values()):
+            widget = self.tree_widget.itemWidget(child_item, 1)
+            if widget:
+                widget.deleteLater()
+            self.header_item.removeChild(child_item)
+        
+        header_widget = self.tree_widget.itemWidget(self.header_item, 1)
+        if header_widget:
+            header_widget.deleteLater()
+        
+        index = self.tree_widget.indexOfTopLevelItem(self.header_item)
+        if index >= 0:
+            self.tree_widget.takeTopLevelItem(index)
+        
+        self.settings_items.clear()
+        self.operation_items.clear()
+
 
 def remove_from_tree(
     name: str,

--- a/helper_funcs.py
+++ b/helper_funcs.py
@@ -25,6 +25,12 @@ class OrderedAttrDict(object):
         self.__dict__[name] = obj
         return obj
 
+    def __delitem__(self, name):
+        if name in self._odict:
+            del self._odict[name]
+            if name in self.__dict__:
+                del self.__dict__[name]
+
     def keys(self):
         return self._odict.keys()
 

--- a/tests/test_dynamic_loading.py
+++ b/tests/test_dynamic_loading.py
@@ -1,0 +1,140 @@
+import sys
+import numpy as np
+import pyqtgraph as pg
+from qtpy import QtWidgets
+from ScopeFoundry import BaseMicroscopeApp, HardwareComponent, Measurement
+
+
+class TestHardware(HardwareComponent):
+    name = "test_hw"
+    
+    def setup(self):
+        self.settings.New("test_setting", dtype=float, initial=1.0, vmin=0, vmax=10, spinbox_decimals=2)
+        self.settings.New("enable", dtype=bool, initial=True)
+        self.settings.New("mode", dtype=str, initial="A", choices=["A", "B", "C"])
+    
+    def connect(self):
+        print(f"{self.name} connected")
+    
+    def disconnect(self):
+        print(f"{self.name} disconnected")
+
+
+class TestMeasurement(Measurement):
+    name = "test_measure"
+    
+    def setup(self):
+        self.settings.New("duration", dtype=float, initial=1.0, unit="s", vmin=0.1, vmax=10)
+        self.settings.New("amplitude", dtype=float, initial=1.0, vmin=0, vmax=5)
+        self.settings.New("frequency", dtype=float, initial=1.0, unit="Hz", vmin=0.1, vmax=100)
+        self.settings.New("enable_noise", dtype=bool, initial=True)
+    
+    def setup_figure(self):
+        self.ui = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(self.ui)
+        
+        controls_widget = self.settings.New_UI(style="form")
+        layout.addWidget(controls_widget)
+        
+        self.plot_widget = pg.PlotWidget()
+        self.plot_widget.setLabel('left', 'Signal')
+        self.plot_widget.setLabel('bottom', 'Time', units='s')
+        layout.addWidget(self.plot_widget)
+        
+        self.plot_line = self.plot_widget.plot([0], [0], pen='y')
+        
+        start_btn = QtWidgets.QPushButton("Start")
+        start_btn.clicked.connect(self.start)
+        stop_btn = QtWidgets.QPushButton("Stop")
+        stop_btn.clicked.connect(self.interrupt)
+        
+        btn_layout = QtWidgets.QHBoxLayout()
+        btn_layout.addWidget(start_btn)
+        btn_layout.addWidget(stop_btn)
+        layout.addLayout(btn_layout)
+        
+        self.data = []
+        self.time_data = []
+    
+    def run(self):
+        import time
+        self.data = []
+        self.time_data = []
+        
+        duration = self.settings['duration']
+        amplitude = self.settings['amplitude']
+        frequency = self.settings['frequency']
+        enable_noise = self.settings['enable_noise']
+        
+        t0 = time.time()
+        while True:
+            if self.interrupt_measurement_called:
+                break
+            
+            t = time.time() - t0
+            if t > duration:
+                break
+            
+            signal = amplitude * np.sin(2 * np.pi * frequency * t)
+            if enable_noise:
+                signal += 0.1 * amplitude * np.random.randn()
+            
+            self.time_data.append(t)
+            self.data.append(signal)
+            
+            self.set_progress(100 * t / duration)
+            time.sleep(0.05)
+    
+    def update_display(self):
+        if len(self.time_data) > 0:
+            self.plot_line.setData(self.time_data, self.data)
+
+
+class TestApp(BaseMicroscopeApp):
+    name = "Dynamic Loading Test"
+    
+    def setup(self):
+        pass
+
+
+if __name__ == '__main__':
+    app = TestApp(sys.argv)
+    
+    print("\n=== Testing Dynamic Hardware Loading ===")
+    hw1 = app.add_hardware(TestHardware)
+    print(f"Added hardware: {hw1.name}")
+    print(f"Hardware list: {list(app.hardware.keys())}")
+    
+    print("\n=== Testing Hardware Removal ===")
+    app.remove_hardware("test_hw")
+    print(f"Hardware list after removal: {list(app.hardware.keys())}")
+    
+    print("\n=== Testing Re-adding Hardware ===")
+    hw2 = app.add_hardware(TestHardware)
+    print(f"Added hardware again: {hw2.name}")
+    print(f"Hardware list: {list(app.hardware.keys())}")
+
+    print("\n=== Testing Dynamic Measurement Loading ===")
+    m1 = app.add_measurement(TestMeasurement)
+    print(f"Added measurement: {m1.name}")
+    print(f"Measurement list: {list(app.measurements.keys())}")
+
+    print("\n=== Testing Measurement Removal ===")
+    app.remove_measurement("test_measure")
+    print(f"Measurement list after removal: {list(app.measurements.keys())}")
+    
+    print("\n=== Testing Re-adding Measurement ===")
+    m2 = app.add_measurement(TestMeasurement)
+    print(f"Added measurement again: {m2.name}")
+    print(f"Measurement list: {list(app.measurements.keys())}")
+    
+    print("\n=== Test Complete ===")
+    print("You should see the tree widget update dynamically.")
+    print("Try the following:")
+    print("  1. Check that the hardware/measurement appears in the tree")
+    print("  2. In the console, run: app.remove_hardware('test_hw')")
+    print("  3. Check that it disappears from the tree")
+    print("  4. Run: app.add_hardware(TestHardware)")
+    print("  5. Check that it reappears")
+    
+    sys.exit(app.exec_())


### PR DESCRIPTION
  Enable runtime addition and removal of hardware and measurement components
  with proper Qt widget cleanup and signal disconnection.

  Changes:
  - Add remove_hardware() and remove_measurement() methods to BaseMicroscopeApp
  - Add remove_lq_collection_from_settings_path() to BaseApp for proper cleanup
  - Add SubtreeManager.cleanup() to remove tree items and disconnect signals
  - Add __delitem__ to OrderedAttrDict to support del operator
  - Store tree widget references (hw_tree, mm_tree) for dynamic updates
  - Dynamically create SubtreeManager when components added after init
  - Automatically load measurement UI and create MDI subwindow on add
  - Replace assertions with ValueError for duplicate component names

  Cleanup includes:
  - Disconnect all Qt signals (settings, operations, widgets)
  - Delete Qt widgets (tree items, buttons, progress bars, UI windows)
  - Stop timers (display update, measurement threads)
  - Remove from settings paths and favorites
  - Clean up MDI subwindows and menu actions

  Test coverage:
  - Add tests/test_dynamic_loading.py with example hardware/measurement
  - Test includes PyQtGraph widgets and signal connections