### PR TITLE
Fix measurement UI overflow in TabbedView (issue #72)

### DIFF
--- a/base_app/base_microscope_app.py
+++ b/base_app/base_microscope_app.py
@@ -158,6 +158,7 @@ class BaseMicroscopeApp(BaseApp):
         self.ui = load_qt_ui_file(self.ui_filename)
         self.ui: Ui_MainWindow = self.ui  # useful for developing - may cause problems
         self.ui.mdiArea.setVisible(self.mdi)
+        self.ui.mdiArea.setMinimumSize(QtCore.QSize(0, 0))
         self.ui.quickaccess_scrollArea.setVisible(self.mdi)
 
         if self.mdi:
@@ -411,12 +412,19 @@ class BaseMicroscopeApp(BaseApp):
         self, widget: QtWidgets.QWidget, name: str
     ) -> QtWidgets.QMdiSubWindow:
         mdiArea: QtWidgets.QMdiArea = self.ui.mdiArea
+
+        scroll = QtWidgets.QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(widget)
+        scroll.setMinimumSize(0, 0)
+
         subwin = mdiArea.addSubWindow(
-            widget,
+            scroll,
             QtCore.Qt.WindowType.CustomizeWindowHint
             | QtCore.Qt.WindowType.WindowTitleHint
             | QtCore.Qt.WindowType.WindowMinMaxButtonsHint,
         )
+        subwin.setMinimumSize(0, 0)
         ignore_on_close(subwin)
         subwin.setWindowTitle(name)
         subwin.setWindowIcon(widget.windowIcon())

--- a/base_app/base_microscope_app_mdi.ui
+++ b/base_app/base_microscope_app_mdi.ui
@@ -88,38 +88,19 @@
        </property>
        <layout class="QVBoxLayout" name="tree_layout"/>
       </widget>
-      <widget class="QScrollArea" name="scrollArea">
-       <property name="widgetResizable">
+      <widget class="QMdiArea" name="mdiArea">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="viewMode">
+        <enum>QMdiArea::ViewMode::TabbedView</enum>
+       </property>
+       <property name="tabsMovable">
         <bool>true</bool>
        </property>
-       <widget class="QWidget" name="scrollAreaWidgetContents_2">
-        <property name="geometry">
-         <rect>
-          <x>0</x>
-          <y>0</y>
-          <width>1298</width>
-          <height>738</height>
-         </rect>
-        </property>
-        <layout class="QVBoxLayout" name="verticalLayout">
-         <item>
-          <widget class="QMdiArea" name="mdiArea">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="viewMode">
-            <enum>QMdiArea::ViewMode::TabbedView</enum>
-           </property>
-           <property name="tabsMovable">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
       </widget>
      </widget>
     </item>


### PR DESCRIPTION
## Summary

Fixes #72 — measurement UIs extending past the visible edge of the tabbed window.

Commit a8bd1f5 wrapped `QMdiArea` in a `QScrollArea` to allow free window resizing. In `TabbedView` mode this caused the active measurement tab to extend past the visible window edge — `QMdiArea`'s content-driven `minimumSizeHint()` inflated the outer scroll area beyond the viewport.

This PR keeps the free-resize behavior that motivated a8bd1f5 while fixing the tab overflow:

- **`base_microscope_app_mdi.ui`**: Restore `QMdiArea` as a direct child of `col_splitter` (remove the outer `QScrollArea` wrapper), and switch its size policy from `MinimumExpanding` to `Expanding` so the window can shrink below `sizeHint()`.
- **`base_microscope_app.py` `_setup_ui_base`**: Zero the minimum size on `QMdiArea` explicitly to override any internal floor from `minimumSizeHint()`.
- **`base_microscope_app.py` `add_mdi_subwin`**: Wrap each measurement widget in a `QScrollArea(widgetResizable=True)` so that when a UI's natural minimum width exceeds the available tab area, scrollbars appear inside the tab instead of forcing the window to grow. Zero the minimum size on both the inner scroll area and the `QMdiSubWindow` so nothing in the chain reintroduces a per-measurement minimum.

The result:
- The app window can be freely resized to any size — preserving the fix from a8bd1f5 / issue #72.
- Active measurement tabs always fit within the visible window area, even when the underlying `.ui` has a large natural minimum size — scrollbars appear inside the tab as needed.

## Test plan

- [x] Resize the window to a small size — confirm it shrinks freely (no large minimum enforced by any measurement UI).
- [x] Resize the window larger — confirm the active measurement tab grows to fill, and plot regions expand via stretch factors.
- [x] Verify the active tab never extends past the window edge in `TabbedView` mode, even for measurement UIs with large minimum widths (a per-tab scrollbar appears instead).
- [x] Switch to `SubWindowView` mode — confirm subwindows still move and resize normally.